### PR TITLE
PFP-268: enable creation of logger widget on demand

### DIFF
--- a/index.js
+++ b/index.js
@@ -59,5 +59,11 @@ log4js.dumpToConsole = function(numMessages) {
 
 require('./lib/util/util').setLog4js(log4js);
 
+// If we are running in a page script, enable users to create a logging widget on demand
+if (typeof window !== 'undefined') {
+	try {
+		require('./lib/widget').createWidget(log4js);
+	} catch (e) {}
+}
 
 module.exports = exports = log4js;

--- a/index.js
+++ b/index.js
@@ -61,9 +61,9 @@ require('./lib/util/util').setLog4js(log4js);
 
 // If we are running in a page script, enable users to create a logging widget on demand
 if (typeof window !== 'undefined') {
-	try {
-		require('./lib/widget').createWidget(log4js);
-	} catch (e) {}
+  try {
+    require('./lib/widget').createWidget(log4js);
+  } catch (e) {}
 }
 
 module.exports = exports = log4js;

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -6,19 +6,20 @@ function createWidget(log4js) {
 
   // 
   function setOption(selectElement, value) {
-      var options = selectElement.options;
-      for (var i = 0, optionsLength = options.length; i < optionsLength; i++) {
-          if (options[i].value == value) {
-              selectElement.selectedIndex = i;
-              return true;
-          }
+    var options = selectElement.options;
+    for (var i = 0, optionsLength = options.length; i < optionsLength; i++) {
+      if (options[i].value == value) {
+        selectElement.selectedIndex = i;
+        return true;
       }
-      return false;
+    }
+    return false;
   }
 
 
   var loggerWindow = null;
   var logMessages = [];
+
   function createLoggerWindow() {
     if (loggerWindow && loggerWindow.parentElement) {
       loggerWindow.parentElement.removeChild(loggerWindow);
@@ -46,7 +47,7 @@ function createWidget(log4js) {
 
     function recurseLoggers(logger, depth) {
       var str = '';
-      for(var i = 0; i < depth; i++) {
+      for (var i = 0; i < depth; i++) {
         str += '--';
       }
       str += logger.name;
@@ -55,7 +56,7 @@ function createWidget(log4js) {
       loggers.push(logger);
 
       console.log(str)
-      logger.children.forEach(c => recurseLoggers(c, depth+1))
+      logger.children.forEach(c => recurseLoggers(c, depth + 1))
     }
     recurseLoggers(logger, 0)
 
@@ -64,10 +65,10 @@ function createWidget(log4js) {
     loggerSelect.id = "loggerSelect";
 
     for (var i = 0; i < names.length; i++) {
-        var option = document.createElement("option");
-        option.value = values[i];
-        option.text = names[i];
-        loggerSelect.appendChild(option);
+      var option = document.createElement("option");
+      option.value = values[i];
+      option.text = names[i];
+      loggerSelect.appendChild(option);
     }
     loggerSelect.onchange = updateLogger;
 
@@ -89,10 +90,10 @@ function createWidget(log4js) {
     levelSelect.id = "levelSelect";
 
     for (var i = 0; i < logLevels.length; i++) {
-        var option = document.createElement("option");
-        option.value = logLevels[i];
-        option.text = logLevels[i];
-        levelSelect.appendChild(option);
+      var option = document.createElement("option");
+      option.value = logLevels[i];
+      option.text = logLevels[i];
+      levelSelect.appendChild(option);
     }
     levelSelect.onchange = updateLogger;
 
@@ -142,28 +143,28 @@ function createWidget(log4js) {
 
     function updateLogger() {
 
-      for (var i=0;i<loggers.length;i++) {
+      for (var i = 0; i < loggers.length; i++) {
         loggers[i].removeAllAppenders();
       }
 
-      var DivAppender = function (log4js) {
+      var DivAppender = function(log4js) {
         this.log4js = log4js;
       };
 
       DivAppender.prototype = new Appender();
       DivAppender.prototype.threshold = log4js.Level[levelSelect.value];
-      DivAppender.prototype.append = function (loggingEvent) {
-          var newElement = document.createElement("div");
+      DivAppender.prototype.append = function(loggingEvent) {
+        var newElement = document.createElement("div");
 
-          newElement.innerHTML = '<b>' + loggingEvent.logger.name + '</b>: ' + loggingEvent.messages.reduce((a, b) => {
-            return a + b;
-          }, "");
-          logConsole.appendChild(newElement);
-          logConsole.scrollTop = logConsole.scrollHeight;
+        newElement.innerHTML = '<b>' + loggingEvent.logger.name + '</b>: ' + loggingEvent.messages.reduce((a, b) => {
+          return a + b;
+        }, "");
+        logConsole.appendChild(newElement);
+        logConsole.scrollTop = logConsole.scrollHeight;
       };
 
 
-      var selectedLogger = loggers.filter(l => l.name===loggerSelect.value)[0];
+      var selectedLogger = loggers.filter(l => l.name === loggerSelect.value)[0];
       if (selectedLogger) {
         var divAppender = new DivAppender(log4js);
         selectedLogger.addAppender(divAppender);

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -2,184 +2,184 @@ var Appender = require('./appenders/appender');
 
 function createWidget(log4js) {
 
-	var logger = log4js.getRootLogger();
+  var logger = log4js.getRootLogger();
 
-	// 
-	function setOption(selectElement, value) {
-	    var options = selectElement.options;
-	    for (var i = 0, optionsLength = options.length; i < optionsLength; i++) {
-	        if (options[i].value == value) {
-	            selectElement.selectedIndex = i;
-	            return true;
-	        }
-	    }
-	    return false;
-	}
-
-
-	var loggerWindow = null;
-	var logMessages = [];
-	function createLoggerWindow() {
-	  if (loggerWindow && loggerWindow.parentElement) {
-	    loggerWindow.parentElement.removeChild(loggerWindow);
-	  }
-
-	  //Create and append select list
-	  loggerWindow = document.createElement("div");
-	  loggerWindow.id = "loggerWindow";
-	  loggerWindow.style.position = "fixed";
-	  loggerWindow.style.top = "0";
-	  loggerWindow.style.right = "0";
-	  loggerWindow.style.background = "rgba(0,0,0,.85)";
-	  loggerWindow.style.zIndex = 9999;
-	  loggerWindow.style.maxWidth = "450px";
-
-	  document.body.appendChild(loggerWindow);
+  // 
+  function setOption(selectElement, value) {
+      var options = selectElement.options;
+      for (var i = 0, optionsLength = options.length; i < optionsLength; i++) {
+          if (options[i].value == value) {
+              selectElement.selectedIndex = i;
+              return true;
+          }
+      }
+      return false;
+  }
 
 
-	  //////////////
+  var loggerWindow = null;
+  var logMessages = [];
+  function createLoggerWindow() {
+    if (loggerWindow && loggerWindow.parentElement) {
+      loggerWindow.parentElement.removeChild(loggerWindow);
+    }
 
-	  //Create array of options to be added
-	  var names = [];
-	  var values = [];
-	  var loggers = [];
+    //Create and append select list
+    loggerWindow = document.createElement("div");
+    loggerWindow.id = "loggerWindow";
+    loggerWindow.style.position = "fixed";
+    loggerWindow.style.top = "0";
+    loggerWindow.style.right = "0";
+    loggerWindow.style.background = "rgba(0,0,0,.85)";
+    loggerWindow.style.zIndex = 9999;
+    loggerWindow.style.maxWidth = "450px";
 
-	  function recurseLoggers(logger, depth) {
-	    var str = '';
-	    for(var i = 0; i < depth; i++) {
-	      str += '--';
-	    }
-	    str += logger.name;
-	    names.push(str);
-	    values.push(logger.name);
-	    loggers.push(logger);
-
-	    console.log(str)
-	    logger.children.forEach(c => recurseLoggers(c, depth+1))
-	  }
-	  recurseLoggers(logger, 0)
+    document.body.appendChild(loggerWindow);
 
 
-	  var loggerSelect = document.createElement("select");
-	  loggerSelect.id = "loggerSelect";
+    //////////////
 
-	  for (var i = 0; i < names.length; i++) {
-	      var option = document.createElement("option");
-	      option.value = values[i];
-	      option.text = names[i];
-	      loggerSelect.appendChild(option);
-	  }
-	  loggerSelect.onchange = updateLogger;
+    //Create array of options to be added
+    var names = [];
+    var values = [];
+    var loggers = [];
 
-	  loggerWindow.appendChild(loggerSelect);
+    function recurseLoggers(logger, depth) {
+      var str = '';
+      for(var i = 0; i < depth; i++) {
+        str += '--';
+      }
+      str += logger.name;
+      names.push(str);
+      values.push(logger.name);
+      loggers.push(logger);
 
-	  //////////
-
-	  const logLevels = [
-	    "ALL",
-	    "DEBUG",
-	    "INFO",
-	    "WARN",
-	    "ERROR",
-	    "FATAL",
-	    "OFF",
-	    "TRACE"
-	  ];
-	  var levelSelect = document.createElement("select");
-	  levelSelect.id = "levelSelect";
-
-	  for (var i = 0; i < logLevels.length; i++) {
-	      var option = document.createElement("option");
-	      option.value = logLevels[i];
-	      option.text = logLevels[i];
-	      levelSelect.appendChild(option);
-	  }
-	  levelSelect.onchange = updateLogger;
-
-	  loggerWindow.appendChild(levelSelect);
+      console.log(str)
+      logger.children.forEach(c => recurseLoggers(c, depth+1))
+    }
+    recurseLoggers(logger, 0)
 
 
-	  ///////////
+    var loggerSelect = document.createElement("select");
+    loggerSelect.id = "loggerSelect";
 
-	  var logConsole = document.createElement("div");
-	  logConsole.id = "logConsole";
-	  logConsole.style.color = "white";
-	  logConsole.style.maxHeight = "200px";
-	  logConsole.style.overflow = "auto";
-	  logConsole.style.fontSize = "8px";
-	  logConsole.style.fontFamily = "Courier";
+    for (var i = 0; i < names.length; i++) {
+        var option = document.createElement("option");
+        option.value = values[i];
+        option.text = names[i];
+        loggerSelect.appendChild(option);
+    }
+    loggerSelect.onchange = updateLogger;
 
-	  /////////////
+    loggerWindow.appendChild(loggerSelect);
 
-	  var clearButton = document.createElement("button");
-	  clearButton.innerHTML = "clear";
-	  clearButton.onclick = () => {
-	    logConsole.innerHTML = "";
-	  };
+    //////////
 
-	  loggerWindow.appendChild(clearButton);
+    const logLevels = [
+      "ALL",
+      "DEBUG",
+      "INFO",
+      "WARN",
+      "ERROR",
+      "FATAL",
+      "OFF",
+      "TRACE"
+    ];
+    var levelSelect = document.createElement("select");
+    levelSelect.id = "levelSelect";
 
-	  var saveButton = document.createElement("button");
-	  saveButton.innerHTML = "save";
-	  saveButton.onclick = () => {
-	    // download to html file
-	    var text = logConsole.innerHTML;
-	    var element = document.createElement('a');
-	    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
-	    element.setAttribute('download', Date.now() + '.htm');
+    for (var i = 0; i < logLevels.length; i++) {
+        var option = document.createElement("option");
+        option.value = logLevels[i];
+        option.text = logLevels[i];
+        levelSelect.appendChild(option);
+    }
+    levelSelect.onchange = updateLogger;
 
-	    element.style.display = 'none';
-	    document.body.appendChild(element);
-	    element.click();
-	    document.body.removeChild(element);
-	  };
-
-	  loggerWindow.appendChild(saveButton);
-
-	  // add the console last
-	  loggerWindow.appendChild(logConsole);
+    loggerWindow.appendChild(levelSelect);
 
 
-	  function updateLogger() {
+    ///////////
 
-	    for (var i=0;i<loggers.length;i++) {
-	      loggers[i].removeAllAppenders();
-	    }
+    var logConsole = document.createElement("div");
+    logConsole.id = "logConsole";
+    logConsole.style.color = "white";
+    logConsole.style.maxHeight = "200px";
+    logConsole.style.overflow = "auto";
+    logConsole.style.fontSize = "8px";
+    logConsole.style.fontFamily = "Courier";
 
-	    var DivAppender = function (log4js) {
-	      this.log4js = log4js;
-	    };
+    /////////////
 
-	    DivAppender.prototype = new Appender();
-	    DivAppender.prototype.threshold = log4js.Level[levelSelect.value];
-	    DivAppender.prototype.append = function (loggingEvent) {
-	        var newElement = document.createElement("div");
+    var clearButton = document.createElement("button");
+    clearButton.innerHTML = "clear";
+    clearButton.onclick = () => {
+      logConsole.innerHTML = "";
+    };
 
-	        newElement.innerHTML = '<b>' + loggingEvent.logger.name + '</b>: ' + loggingEvent.messages.reduce((a, b) => {
-	          return a + b;
-	        }, "");
-	        logConsole.appendChild(newElement);
-	        logConsole.scrollTop = logConsole.scrollHeight;
-	    };
+    loggerWindow.appendChild(clearButton);
+
+    var saveButton = document.createElement("button");
+    saveButton.innerHTML = "save";
+    saveButton.onclick = () => {
+      // download to html file
+      var text = logConsole.innerHTML;
+      var element = document.createElement('a');
+      element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+      element.setAttribute('download', Date.now() + '.htm');
+
+      element.style.display = 'none';
+      document.body.appendChild(element);
+      element.click();
+      document.body.removeChild(element);
+    };
+
+    loggerWindow.appendChild(saveButton);
+
+    // add the console last
+    loggerWindow.appendChild(logConsole);
 
 
-	    var selectedLogger = loggers.filter(l => l.name===loggerSelect.value)[0];
-	    if (selectedLogger) {
-	      var divAppender = new DivAppender(log4js);
-	      selectedLogger.addAppender(divAppender);
-	    }
+    function updateLogger() {
 
-	  }
+      for (var i=0;i<loggers.length;i++) {
+        loggers[i].removeAllAppenders();
+      }
 
-	  updateLogger();
+      var DivAppender = function (log4js) {
+        this.log4js = log4js;
+      };
 
-	}
+      DivAppender.prototype = new Appender();
+      DivAppender.prototype.threshold = log4js.Level[levelSelect.value];
+      DivAppender.prototype.append = function (loggingEvent) {
+          var newElement = document.createElement("div");
 
-	window.createLoggerWindow = createLoggerWindow;
-	window.log4jsLogger = logger;
+          newElement.innerHTML = '<b>' + loggingEvent.logger.name + '</b>: ' + loggingEvent.messages.reduce((a, b) => {
+            return a + b;
+          }, "");
+          logConsole.appendChild(newElement);
+          logConsole.scrollTop = logConsole.scrollHeight;
+      };
+
+
+      var selectedLogger = loggers.filter(l => l.name===loggerSelect.value)[0];
+      if (selectedLogger) {
+        var divAppender = new DivAppender(log4js);
+        selectedLogger.addAppender(divAppender);
+      }
+
+    }
+
+    updateLogger();
+
+  }
+
+  window.createLoggerWindow = createLoggerWindow;
+  window.log4jsLogger = logger;
 }
 
 
 module.exports = exports = {
-	createWidget: createWidget
+  createWidget: createWidget
 };

--- a/lib/widget.js
+++ b/lib/widget.js
@@ -1,0 +1,185 @@
+var Appender = require('./appenders/appender');
+
+function createWidget(log4js) {
+
+	var logger = log4js.getRootLogger();
+
+	// 
+	function setOption(selectElement, value) {
+	    var options = selectElement.options;
+	    for (var i = 0, optionsLength = options.length; i < optionsLength; i++) {
+	        if (options[i].value == value) {
+	            selectElement.selectedIndex = i;
+	            return true;
+	        }
+	    }
+	    return false;
+	}
+
+
+	var loggerWindow = null;
+	var logMessages = [];
+	function createLoggerWindow() {
+	  if (loggerWindow && loggerWindow.parentElement) {
+	    loggerWindow.parentElement.removeChild(loggerWindow);
+	  }
+
+	  //Create and append select list
+	  loggerWindow = document.createElement("div");
+	  loggerWindow.id = "loggerWindow";
+	  loggerWindow.style.position = "fixed";
+	  loggerWindow.style.top = "0";
+	  loggerWindow.style.right = "0";
+	  loggerWindow.style.background = "rgba(0,0,0,.85)";
+	  loggerWindow.style.zIndex = 9999;
+	  loggerWindow.style.maxWidth = "450px";
+
+	  document.body.appendChild(loggerWindow);
+
+
+	  //////////////
+
+	  //Create array of options to be added
+	  var names = [];
+	  var values = [];
+	  var loggers = [];
+
+	  function recurseLoggers(logger, depth) {
+	    var str = '';
+	    for(var i = 0; i < depth; i++) {
+	      str += '--';
+	    }
+	    str += logger.name;
+	    names.push(str);
+	    values.push(logger.name);
+	    loggers.push(logger);
+
+	    console.log(str)
+	    logger.children.forEach(c => recurseLoggers(c, depth+1))
+	  }
+	  recurseLoggers(logger, 0)
+
+
+	  var loggerSelect = document.createElement("select");
+	  loggerSelect.id = "loggerSelect";
+
+	  for (var i = 0; i < names.length; i++) {
+	      var option = document.createElement("option");
+	      option.value = values[i];
+	      option.text = names[i];
+	      loggerSelect.appendChild(option);
+	  }
+	  loggerSelect.onchange = updateLogger;
+
+	  loggerWindow.appendChild(loggerSelect);
+
+	  //////////
+
+	  const logLevels = [
+	    "ALL",
+	    "DEBUG",
+	    "INFO",
+	    "WARN",
+	    "ERROR",
+	    "FATAL",
+	    "OFF",
+	    "TRACE"
+	  ];
+	  var levelSelect = document.createElement("select");
+	  levelSelect.id = "levelSelect";
+
+	  for (var i = 0; i < logLevels.length; i++) {
+	      var option = document.createElement("option");
+	      option.value = logLevels[i];
+	      option.text = logLevels[i];
+	      levelSelect.appendChild(option);
+	  }
+	  levelSelect.onchange = updateLogger;
+
+	  loggerWindow.appendChild(levelSelect);
+
+
+	  ///////////
+
+	  var logConsole = document.createElement("div");
+	  logConsole.id = "logConsole";
+	  logConsole.style.color = "white";
+	  logConsole.style.maxHeight = "200px";
+	  logConsole.style.overflow = "auto";
+	  logConsole.style.fontSize = "8px";
+	  logConsole.style.fontFamily = "Courier";
+
+	  /////////////
+
+	  var clearButton = document.createElement("button");
+	  clearButton.innerHTML = "clear";
+	  clearButton.onclick = () => {
+	    logConsole.innerHTML = "";
+	  };
+
+	  loggerWindow.appendChild(clearButton);
+
+	  var saveButton = document.createElement("button");
+	  saveButton.innerHTML = "save";
+	  saveButton.onclick = () => {
+	    // download to html file
+	    var text = logConsole.innerHTML;
+	    var element = document.createElement('a');
+	    element.setAttribute('href', 'data:text/plain;charset=utf-8,' + encodeURIComponent(text));
+	    element.setAttribute('download', Date.now() + '.htm');
+
+	    element.style.display = 'none';
+	    document.body.appendChild(element);
+	    element.click();
+	    document.body.removeChild(element);
+	  };
+
+	  loggerWindow.appendChild(saveButton);
+
+	  // add the console last
+	  loggerWindow.appendChild(logConsole);
+
+
+	  function updateLogger() {
+
+	    for (var i=0;i<loggers.length;i++) {
+	      loggers[i].removeAllAppenders();
+	    }
+
+	    var DivAppender = function (log4js) {
+	      this.log4js = log4js;
+	    };
+
+	    DivAppender.prototype = new Appender();
+	    DivAppender.prototype.threshold = log4js.Level[levelSelect.value];
+	    DivAppender.prototype.append = function (loggingEvent) {
+	        var newElement = document.createElement("div");
+
+	        newElement.innerHTML = '<b>' + loggingEvent.logger.name + '</b>: ' + loggingEvent.messages.reduce((a, b) => {
+	          return a + b;
+	        }, "");
+	        logConsole.appendChild(newElement);
+	        logConsole.scrollTop = logConsole.scrollHeight;
+	    };
+
+
+	    var selectedLogger = loggers.filter(l => l.name===loggerSelect.value)[0];
+	    if (selectedLogger) {
+	      var divAppender = new DivAppender(log4js);
+	      selectedLogger.addAppender(divAppender);
+	    }
+
+	  }
+
+	  updateLogger();
+
+	}
+
+	window.createLoggerWindow = createLoggerWindow;
+	window.log4jsLogger = logger;
+}
+
+
+module.exports = exports = {
+	createWidget: createWidget
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "log4js",
   "repo": "virtru-components/log4js",
   "description": "",
-  "version": "0.0.11",
+  "version": "0.0.12",
   "dependencies": {
   }
 }


### PR DESCRIPTION
<img width="643" alt="Screen Shot 2019-08-23 at 2 33 12 PM" src="https://user-images.githubusercontent.com/27253228/63618938-f82c1580-c5b2-11e9-9d38-80074589d1a1.png">

This PR enables users to run the command from console or bookmarklet `createLoggerWindow()` in order to gather logs from runtime. Enables easy debugging, in any environment, without opening console.

<img width="510" alt="Screen Shot 2019-08-23 at 2 38 49 PM" src="https://user-images.githubusercontent.com/27253228/63619262-bfd90700-c5b3-11e9-8317-98d61bf62c0c.png">
